### PR TITLE
fix: land rc.d decoupling on main + refuse running as root

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,109 @@
 # .config
-dotfiles for sanath using XDG Base Spec
 
-## organization:
+Portable, XDG-based personal dotfiles: zsh, tmux, powerlevel10k, git, homebrew,
+raycast, vscode. Self-contained — on any fresh machine `./setup.sh` gives a
+working personal shell. Machine- or work-specific config layers on top through a
+`zsh/rc.d` extension point, so this repo never needs to know those layers exist.
 
-```
-├── README.md                   -> this doc :) 
-├── aliases                     -> dir to hold personal custom aliases
-├── apple
-│   └── apple.sh                -> apple specific setup, run only on new macs
-├── commands                    -> will be deprecated, and, moved into aliases
-├── git
-│   └── .gitconfig.personal     -> personal sanathkumarbs gitconfig
-├── homebrew
-│   ├── Brewfile                -> brews that i love
-│   └── Brewfile-minimal        -> minimal brew for remote machines
-├── setup.sh                    -> setting up the configs by moving things to $HOME/.config 
-├── packages.sh                 -> sets up packages using a combinaiton of apt and from sources (used mainly for non-brew situations)
-├── tmux
-│   └── tmux.conf               -> sets up tmux how i like it :)
-├── vscode
-│   └── software.json           -> extensions on vscode that i rely on
-└── zsh
-    ├── .p10k.zsh               -> powerlevel10k config
-    ├── .zprofile               -> personal zsh configs
-    ├── .zshenv                 -> personal zsh configs
-    └── .zshrc                  -> personal zsh configs
-```
+## Architecture
 
-## zsh setup notes:
+Three independent layers, composed by a bootstrap entrypoint — not by this repo:
 
-Work dotfiles should be hosted at `$HOME/work/dotfiles` which will setup if they're found:
+1. **`.config` (this repo, public)** — the portable base. Sets up zsh (via
+   `ZDOTDIR`), oh-my-zsh, powerlevel10k, tmux, homebrew, etc. Knows nothing about
+   any employer, host, or private tooling.
+2. **A private overlay (optional)** — e.g. work dotfiles. It installs its own
+   zshrc as `~/.config/zsh/rc.d/50-*.zsh` and its aliases into
+   `~/.config/aliases/`. Present only on machines where it has been set up.
+3. **A bootstrap entrypoint** — clones layer 1 and runs its `setup.sh`, then
+   clones layer 2 and runs its `setup.sh`. This is the *only* place the layers
+   are composed. On a personal machine you run layer 1 alone and `rc.d` stays
+   empty; everything still works.
+
+The rule: dependencies point **up**, never down. The overlay and bootstrap know
+about `.config`; `.config` knows about neither.
+
+### Boot chain
 
 ```
-if [ -f "$HOME"/work/dotfiles/setup.sh ]; then
-  echo "setting up work dotfiles... "
-  # shellcheck source=/dev/null
-  source "$HOME"/work/dotfiles/setup.sh
-else
-  echo "failed to setup work dotfiles, setup.sh not found in $HOME/work/dotfiles/"
-fi
+zsh startup
+  → /etc/zshenv                                  (system)
+  → ~/.zshenv          (copy of zsh/.zshenv)     sets ZDOTDIR=~/.config/zsh
+  → $ZDOTDIR/.zshrc    (symlink → this repo)     p10k, oh-my-zsh, plugins, then:
+        for f in $ZDOTDIR/rc.d/*.zsh; do source $f; done   ← extension point
+              └─ 50-*.zsh → (overlay) zshrc → overlay aliases + shell init
 ```
 
-Additionally, work dotfiles should contain it's own `zshrc` config which will be sourced if present from the `zsh/.zshrc` present in this repo
+`~/.zshenv` is the load-bearing file. It is the one rc file zsh autoloads from
+`$HOME`, and all it does is point `ZDOTDIR` at `~/.config/zsh` so every other rc
+file lives under XDG paths. `setup.sh` copies it into `$HOME`. If a new shell
+comes up with the wrong prompt and no custom config, check `echo $ZDOTDIR`
+first — an empty value means `~/.zshenv` did not autoload and nothing downstream
+will run.
 
-```
-if [[ -f ~/work/dotfiles/zshrc ]]; then
-  source ~/work/dotfiles/zshrc
-fi
-
-```
-
-how `$HOME/work/dotfiles` should be organized
+## Layout
 
 ```
 .
-├── .bash_profile.atlas.aliases     -> work specific bash aliases
-├── README.md                       -> document! document!
-├── setup.sh                        -> setting up aliases or any configs into $HOME/.config 
-└── zshrc                           -> work specific zshrc configs
+├── README.md                -> this doc
+├── SECURITY.md
+├── setup.sh                 -> symlinks/copies configs into place; creates rc.d
+├── packages.sh              -> non-brew package setup (apt / from source)
+├── apple/apple.sh           -> macOS-only setup, run once per new mac
+├── git/.gitconfig.personal  -> personal git identity
+├── homebrew/
+│   ├── Brewfile             -> full brew set
+│   └── Brewfile-minimal     -> minimal set for remote machines
+├── tmux/tmux.conf
+├── vscode/software.json     -> extensions to install
+├── raycast/                 -> raycast config
+├── commands/                -> (deprecating) custom commands
+└── zsh/
+    ├── .zshenv              -> sets XDG + ZDOTDIR (copied to $HOME)
+    ├── .zshrc               -> oh-my-zsh, p10k, sources rc.d/*.zsh
+    ├── .zprofile
+    ├── .p10k.zsh
+    ├── oh-my-zsh/           -> installed by setup.sh
+    └── rc.d/                -> extension point (created by setup.sh, populated
+                                by overlays; empty on a personal machine)
 ```
+
+`~/.config/aliases/` is created at setup time and holds alias files symlinked in
+by an overlay; it is not tracked here.
+
+## Setup
+
+Personal machine (this repo only):
+
+```
+git clone https://github.com/sanathkumarbs/.config.git ~/personal/.config
+~/personal/.config/setup.sh
+```
+
+This installs zsh/oh-my-zsh/p10k/plugins/tmux and creates the
+`~/.config/zsh/rc.d` extension point. Open a new shell. `setup.sh` calls `sudo`,
+so run it yourself in a real terminal (it prompts for a password).
+
+Full machine (base + private overlay): run your bootstrap entrypoint, which
+composes both layers in order.
+
+## Adding a machine or work overlay
+
+An overlay is any repo that drops a `*.zsh` into `~/.config/zsh/rc.d/`. Files are
+sourced in lexical order, so prefix with a number (`50-…`) to control ordering.
+The overlay's own `setup.sh` should symlink its zshrc in, e.g.:
+
+```
+ln -sf "$OVERLAY_DIR/zshrc" ~/.config/zsh/rc.d/50-work.zsh
+```
+
+That zshrc can then source aliases from `~/.config/aliases/`, load private shell
+init, etc. Because `.config` only globs `rc.d/*.zsh`, an empty `rc.d` is a no-op
+and the base stays fully functional on its own.
+
+## Notes
+
+- XDG base directories are set in `zsh/.zshenv`; `ZDOTDIR` redirects all zsh rc
+  files under `~/.config/zsh`.
+- The default branch is `main` — a fresh bootstrap clones `main`, so land changes
+  there for them to reach new machines.

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 set -euxo pipefail
 
-sudo -v
-# Keep-alive: update existing `sudo` time stamp until script has finished
-while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
+# This sets up per-user config and clones repos over your SSH keys. Running as
+# root (e.g. via `sudo`) makes everything root-owned and breaks GHE auth (root
+# has no SSH key). Refuse it — nothing here needs root.
+if [ "$(id -u)" -eq 0 ]; then
+  echo "Do NOT run this as root / with sudo. Run it as your normal user." >&2
+  exit 1
+fi
 
 function dotfiles_location() {
   echo "$HOME/personal/.config"
@@ -84,10 +88,10 @@ symlink_dotfile tmux/tmux.conf "$HOME"/.config/tmux/.tmux.conf
 symlink_dotfile tmux/tmux.conf ~/.tmux.conf
 echo "finished setting up tmux... 🚀"
 
-if [ -f "$HOME"/work/dotfiles/setup.sh ]; then
-  echo "setting up work dotfiles... "
-  # shellcheck source=/dev/null
-  source "$HOME"/work/dotfiles/setup.sh
-else
-  echo "failed to setup work dotfiles, setup.sh not found in $HOME/work/dotfiles/"
-fi
+# Extension point for machine-specific / work overrides. .config itself stays
+# portable and independent; layers on top (e.g. Stripe work dotfiles) drop a
+# *.zsh into here and it gets sourced by zsh/.zshrc. Composition of those layers
+# is the job of the bootstrap entrypoint, not this repo.
+echo "creating zsh extension point (~/.config/zsh/rc.d)"
+mkdir -p "$HOME"/.config/zsh/rc.d
+echo "finished personal setup... 🚀"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -128,17 +128,14 @@ alias cookit='tc && cz'
 [[ ! -f ~/.config/zsh/.p10k.zsh ]] || source ~/.config/zsh/.p10k.zsh
 
 
-# TODO (sanath, 15-08-2024):
-# ~/work/dotfiles/zshrc is where files are present locally, and
-# /home/sanath/personal/dotfiles/zshrc is where it's present on remote
-# bring them to a common place at ~/.config maybe and source that so it works the same way on remote and local
-if [[ -f ~/work/dotfiles/zshrc ]]; then
-  source ~/work/dotfiles/zshrc
-fi
-
-if [[ -f /home/sanath/personal/dotfiles/zshrc ]]; then
-  source /home/sanath/personal/dotfiles/zshrc
-fi
+# Machine-specific / work extension point. .config stays portable and knows
+# nothing about work: any *.zsh dropped into $ZDOTDIR/rc.d is sourced if present
+# (e.g. the Stripe work dotfiles symlink their zshrc to rc.d/50-stripe.zsh).
+# On a personal machine rc.d is empty and this is a no-op.
+for _rc in "${ZDOTDIR:-$HOME/.config/zsh}"/rc.d/*.zsh(N); do
+  source "$_rc"
+done
+unset _rc
 
 # Determine the operating system
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
Bring main up to the rc.d extension-point architecture (setup.sh, zsh/.zshrc, README) — main was still on the old ~/work/dotfiles sourcing, so any fresh bootstrap re-cloned the broken config.

Also make setup.sh refuse to run as root: running the bootstrap under sudo clones everything root-owned and breaks GHE SSH auth (root has no key).

Committed-By-Agent: claude